### PR TITLE
Make the sound works on Ubuntu

### DIFF
--- a/Java/src/main/java/net/davidtanzer/babysteps/BabystepsTimer.java
+++ b/Java/src/main/java/net/davidtanzer/babysteps/BabystepsTimer.java
@@ -129,7 +129,7 @@ public class BabystepsTimer {
 			@Override
 			public void run() {
 				try {
-					Clip clip = AudioSystem.getClip();
+					Clip clip = AudioSystem.getClip(null);
 					AudioInputStream inputStream = AudioSystem.getAudioInputStream(
 							BabystepsTimer.class.getResourceAsStream("/"+url));
 					clip.open(inputStream);


### PR DESCRIPTION
On Ubuntu the AudioSystem does not play sound and display a "Invalid Format" error message.

Adding "null" as info parameter seems to solve the problem, cf
https://stackoverflow.com/questions/18942424/error-playing-audio-file-from-java-via-pulseaudio-on-ubuntu